### PR TITLE
Send Authorize.net charge request as HTTP POST

### DIFF
--- a/cmPaymentGatewayANET.class.php
+++ b/cmPaymentGatewayANET.class.php
@@ -243,6 +243,7 @@ class cmPaymentGatewayANET extends cmPaymentGateway {
     function send($req) {
         $url = ($this->testmode)? $this->_transact_url_test : $this->_transact_url;
         $http = new HTTP_Request($url . '?' . $req);
+	$http->setMethod(HTTP_REQUEST_METHOD_POST);
         if (PEAR::isError($http->sendRequest())) {
             return $http;
         }


### PR DESCRIPTION
Authorize.net deprecated GET and stopped supporting it entirely on 31 May 2017.  While the recommended solution is to upgrade to their new API, simply changing the HTTP REQUEST verb from "GET" to "POST" solves this breaking change.